### PR TITLE
Security: latest vue-socket.io 2.x 📦

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "register-service-worker": "^1.4.1",
     "vue": "^2.5.13",
     "vue-router": "^3.0.1",
-    "vue-socket.io": "^2.1.1",
+    "vue-socket.io": "~2.1.1-b",
     "vuetify": "^1.1.7",
     "vuex": "^3.0.1",
     "vuex-persistedstate": "^2.5.4",


### PR DESCRIPTION
`npm audit` shows that a denial of service is present in `vue-socket.io@2.1.1`

This commit fixes this, by update of `vue-socket.io` to `2.1.1-b`

For now we are avoiding breaking API changes. introduces in `vue-socket.io@3.x`