### PR TITLE
Remove words from custom wordbank when starting a new game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1545,7 +1545,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -11147,7 +11147,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -11317,7 +11317,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -11601,7 +11601,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -115,7 +115,7 @@ def on_flip_card(data):
 def on_regenerate(data):
     """regenerate the words list"""
     room = data['room']
-    ROOMS[room].generate_board()
+    ROOMS[room].generate_board(data.get('newGame', False))
     send(ROOMS[room].to_json(), room=room)
 
 @socketio.on('list_dictionaries')

--- a/server/codenames/game.py
+++ b/server/codenames/game.py
@@ -46,6 +46,7 @@ class Info(object):
         self.dictionary = dictionary
         self.mix = mix
         self.dictionaries = DICTIONARIES.keys()
+        self.minWords = BOARD_SIZE[self.size]
 
         # gererate board
         self.generate_board()
@@ -65,13 +66,18 @@ class Info(object):
                 "dictionary": self.dictionary,
                 "size": self.size,
                 "teams": self.teams,
-                "mix": self.mix
+                "mix": self.mix,
+                "custom": self.wordbank
             },
 
         }
 
-    def generate_board(self):
+    def generate_board(self, newGame=False):
         """Generate a list of words"""
+        # remove current words from bank if newGame and not shuffle
+        if newGame and hasattr(self, 'words') and (self.wordbank and len(self.wordbank) - self.minWords >= self.minWords):
+            for word in self.words:
+                self.wordbank.remove(word)
         self.words = self.__get_words(self.size)
         self.layout = self.__get_layout(self.size, int(self.teams))
         self.board = dict.fromkeys(self.words, False)

--- a/src/views/Spymaster.vue
+++ b/src/views/Spymaster.vue
@@ -48,14 +48,15 @@ export default {
     ...mapMutations(['set_room', 'set_username', 'reveal_spymaster', 'reset_room']),
     newGame(reset) {
       // reset spymaster state and go to player view
-      if (reset === true) {
-        this.reset_room()
-        this.$router.push({ path: `/${this.room}/player` })
-      }
       // emit message to start a new game
       const params = {
         room: this.room,
       };
+      if (reset === true) {
+        this.reset_room()
+        params['newGame'] = true
+        this.$router.push({ path: `/${this.room}/player` })
+      }
       this.$socket.emit('regenerate', params);
     },
   },


### PR DESCRIPTION
- When playing consecutive games with a custom wordbank, remove words from previous round
- Add flag to `regenerate_board` call to signify whether it's a new game vs a board reshuffle
- Minor update from client to send corresponding flag