### PR TITLE
Ensure unique gameboards for default dictionaries.

### DIFF
--- a/server/codenames/game.py
+++ b/server/codenames/game.py
@@ -71,7 +71,7 @@ class Game(object):
     def generate_board(self, newGame=False):
         """Generate a list of words"""
         # remove current words from bank if newGame and not shuffle
-        if newGame and hasattr(self, 'words'):
+        if newGame and hasattr(self, 'words') and not self.mix:
             if (self.wordbank and len(self.wordbank) - self.minWords >= self.minWords):
                 for word in self.words:
                     self.wordbank.remove(word)


### PR DESCRIPTION
When default dictionary is chosen, it's stored in the word bank so that new games will draw only from words not yet used. 

When the end of a wordbank is reached, it's reset to the original default dictionary or custom word bank.

Mixed dictionary behavior is unaffected.